### PR TITLE
Add optional YouTube organic retention signal

### DIFF
--- a/analysis/hype.py
+++ b/analysis/hype.py
@@ -1,28 +1,34 @@
-"""Audience hype signals fetched WITHOUT platform API keys.
+"""Audience hype signals, all optional and failure-safe.
 
-Two sources, both optional and failure-safe (processing works identically
-without them — this only ever ADDS a small scoring bonus):
+Processing works identically without them: audience data only ever ADDS a
+small scoring bonus and can also seed candidate windows around audience peaks.
 
+Sources:
 - Twitch VODs: the public web GQL endpoint every chat-replay tool uses.
   The Client-ID is scraped from twitch.tv itself at call time, because
   Twitch rotates it (hardcoded IDs from 2023-era tools now 400).
-- YouTube: the "most replayed" heatmap yt-dlp exposes for popular videos,
-  and chat replay (live_chat) for finished live streams.
-- Kick: NOT possible — Kick deletes chat when a stream ends and has no
-  replay endpoint (verified 2026-07); Kick hype comes from audio/visual
-  signals only.
+- YouTube, authenticated: the creator's organic audience-retention curve from
+  YouTube Analytics, when a cached OAuth token includes yt-analytics.readonly.
+  The raw retention curve is locally detrended before percentile ranking so
+  ordinary retention decay does not make the start of every video look "hot".
+- YouTube, public fallback: the "most replayed" heatmap yt-dlp exposes for
+  popular videos, then chat replay (live_chat) for finished live streams.
+- Kick: NOT possible — Kick deletes chat when a stream ends and has no replay
+  endpoint (verified 2026-07); Kick hype comes from audio/visual signals only.
 
-Gift-sub / bits resistance: the curve counts UNIQUE CHATTERS per time bin,
-not messages. A gifted-sub bomb produces a burst of messages from few
-humans (plus bots), which barely moves unique-chatter density — so fake
-"hype" from sub trains doesn't outrank a genuinely popping chat. The bonus
-is also hard-capped in fusion so transcript/visual context stays dominant.
+Gift-sub / bits resistance: the Twitch curve counts UNIQUE CHATTERS per time
+bin, not messages. A gifted-sub bomb produces a burst of messages from few
+humans (plus bots), which barely moves unique-chatter density — so fake "hype"
+from sub trains doesn't outrank a genuinely popping chat. The bonus is also
+hard-capped in fusion so transcript/visual context stays dominant.
 """
 
 import json
+import os
 import re
 import time
 import urllib.request
+from datetime import date
 from pathlib import Path
 
 import numpy as np
@@ -35,6 +41,18 @@ _UA = (
 )
 _MAX_PAGES = 800          # ~48k messages — covers long VODs
 _TIME_BUDGET_S = 180      # never stall the pipeline on a slow chat fetch
+_YT_ANALYTICS_SCOPE = "https://www.googleapis.com/auth/yt-analytics.readonly"
+_RETENTION_BASELINE_RADIUS = 4
+_RETENTION_IGNORE_START_RATIO = 0.05
+
+# Clips Kitty consumes audience as a CLIP-level signal: fusion averages the
+# curve across each candidate and only bonuses windows whose mean is near the
+# top. Organic retention, however, arrives as narrow 1%-of-video samples.
+# Spread each local-retention peak into a short, gently-decaying interest zone
+# so a real audience moment can survive that clip-window averaging without
+# moving the peak or inventing new peaks.
+_RETENTION_CLIP_RADIUS_SECONDS = 12
+_RETENTION_EDGE_WEIGHT = 0.925
 
 
 def audience_curve(url: str, video_id: str, duration: float) -> np.ndarray | None:
@@ -46,11 +64,18 @@ def audience_curve(url: str, video_id: str, duration: float) -> np.ndarray | Non
             return _chatters_to_curve(times, duration)
         if video_id.startswith("kick_"):
             return None  # Kick retains no chat after the stream ends
-        # YouTube: prefer the most-replayed heatmap; fall back to live-chat
-        # replay for finished live streams.
+
+        # YouTube: private organic retention is the best signal when the user
+        # has already authorized it. No token / wrong channel / no data is a
+        # normal condition, so each case falls through to the public sources.
+        organic = _youtube_organic_retention(video_id, duration)
+        if organic is not None:
+            return organic
+
         heat = _youtube_heatmap(url, duration)
         if heat is not None:
             return heat
+
         times = _youtube_live_chat(url, video_id, duration)
         return _chatters_to_curve(times, duration)
     except Exception as e:
@@ -83,7 +108,6 @@ query($videoID: ID!, $offset: Int) {
 
 def _twitch_chat(vod_id: str, duration: float) -> list[tuple[float, str]]:
     """(offset_seconds, chatter_id) for the whole VOD's chat replay.
-
     Paged by contentOffsetSeconds, NOT cursors: cursor pagination trips
     Twitch's client-integrity check (2026), while offset queries — 'give me
     the chat page at second X' — pass. Each page spans until its last
@@ -134,11 +158,217 @@ def _twitch_chat(vod_id: str, duration: float) -> list[tuple[float, str]]:
 # ---- YouTube ----------------------------------------------------------------
 
 
+def _youtube_token_path() -> Path:
+    """The token written by `python main.py auth`.
+
+    Electron passes CLIPS_STUDIO_DATA_DIR for installed builds. A source
+    checkout with default settings resolves to repo/data. A custom CLI data
+    directory that is not also exported through the environment simply means
+    this optional signal is unavailable, so the public fallback still works.
+    """
+    override = os.environ.get("CLIPS_STUDIO_DATA_DIR")
+    if override:
+        return Path(override) / "youtube_token.json"
+
+    from core.paths import resolve_data_dir
+
+    return resolve_data_dir({}) / "youtube_token.json"
+
+
+def _youtube_organic_retention(video_id: str, duration: float) -> np.ndarray | None:
+    """Creator-only organic audience retention via YouTube Analytics.
+
+    This function is deliberately non-interactive. It never opens a browser:
+    if the cached token is absent, lacks the Analytics scope, belongs to an
+    account that cannot read this video, or the video has no retention yet,
+    return None and let audience_curve() use the existing public path.
+    """
+    token_path = _youtube_token_path()
+    if not token_path.exists():
+        return None
+
+    try:
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
+
+        creds = Credentials.from_authorized_user_file(str(token_path))
+
+        if not creds.has_scopes([_YT_ANALYTICS_SCOPE]):
+            return None
+
+        if creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+            token_path.write_text(creds.to_json(), encoding="utf-8")
+
+        if not creds.valid:
+            return None
+
+        analytics = build(
+            "youtubeAnalytics",
+            "v2",
+            credentials=creds,
+            cache_discovery=False,
+        )
+        report = analytics.reports().query(
+            ids="channel==MINE",
+            startDate="2005-04-23",
+            endDate=date.today().isoformat(),
+            metrics="audienceWatchRatio",
+            dimensions="elapsedVideoTimeRatio",
+            filters=f"video=={video_id};audienceType==ORGANIC",
+            sort="elapsedVideoTimeRatio",
+        ).execute()
+
+        rows = report.get("rows") or []
+        curve = _retention_rows_to_curve(rows, duration)
+        if curve is not None:
+            print(f"      YouTube organic retention loaded ({len(rows)} bins, OAuth)")
+        return curve
+    except Exception:
+        # Expected fallbacks include: token revoked, Analytics API disabled,
+        # someone else's video, and a new/low-view video with no retention.
+        return None
+
+
+def _retention_rows_to_curve(rows: list, duration: float) -> np.ndarray | None:
+    """Convert Analytics retention rows into Clips Kitty's per-second 0..1 signal.
+
+    audienceWatchRatio naturally slopes down through almost every video. Using
+    the raw values would therefore label the intro as the hottest part even
+    when viewers never replayed or held there. Instead each 1%-of-video point
+    is compared with the median on both sides (the same local-prominence idea
+    validated against YouTube Studio), then those lifts are percentile-ranked
+    within the video, matching the normalization convention used by the other
+    Clips Kitty signals.
+
+    The first 5% is deliberately suppressed: startup retention is dominated by
+    autoplay, immediate exits and values over 100%, not a meaningful "moment".
+
+    Finally, the per-second prominence curve is converted into a clip-scale
+    interest envelope. Clips Kitty averages audience values over a whole clip;
+    a genuine 1%-bin retention spike would otherwise be diluted almost to
+    nothing inside a 25-60s candidate. The envelope keeps the maximum at the
+    exact same second and lets its influence decay gently for 12s on either
+    side. This is analogous to turning a point measurement into the short
+    "hot zone" that the existing Most Replayed/chat curves already represent.
+    """
+    if duration <= 0 or len(rows) < 5:
+        return None
+
+    points: list[tuple[float, float]] = []
+    for row in rows:
+        try:
+            ratio = float(row[0])
+            watch = float(row[1])
+        except (TypeError, ValueError, IndexError):
+            continue
+        if np.isfinite(ratio) and np.isfinite(watch) and 0.0 <= ratio <= 1.0:
+            points.append((ratio, watch))
+
+    if len(points) < 5:
+        return None
+
+    points.sort(key=lambda p: p[0])
+
+    # Duplicate ratios are not expected, but collapsing them avoids np.interp
+    # ambiguity if the API ever returns one.
+    collapsed: list[tuple[float, float]] = []
+    for ratio, watch in points:
+        if collapsed and abs(collapsed[-1][0] - ratio) < 1e-9:
+            collapsed[-1] = (ratio, max(collapsed[-1][1], watch))
+        else:
+            collapsed.append((ratio, watch))
+
+    ratios = np.asarray([p[0] for p in collapsed], dtype=np.float32)
+    values = np.asarray([p[1] for p in collapsed], dtype=np.float32)
+    n = values.size
+    if n < 5:
+        return None
+
+    lift = np.empty(n, dtype=np.float32)
+
+    for i, current in enumerate(values):
+        left = values[max(0, i - _RETENTION_BASELINE_RADIUS):i]
+        right = values[i + 1:min(n, i + _RETENTION_BASELINE_RADIUS + 1)]
+
+        if left.size and right.size:
+            # Using the higher side is conservative on a naturally declining
+            # retention curve: only an actual local rise earns a strong lift.
+            baseline = max(float(np.median(left)), float(np.median(right)))
+        elif left.size:
+            baseline = float(np.median(left))
+        elif right.size:
+            baseline = float(np.median(right))
+        else:
+            baseline = float(current)
+
+        lift[i] = float(current) - baseline
+
+    # The intro behaves unlike the rest of a retention graph; make it cold
+    # before percentile ranking rather than letting 100%+ startup values win.
+    intro = ratios < _RETENTION_IGNORE_START_RATIO
+    if intro.any():
+        floor = float(lift.min()) - max(float(np.ptp(lift)), 1e-6) - 1.0
+        lift[intro] = floor
+
+    # Same percentile-rank convention as analysis/fusion.py::_pct.
+    order = lift.argsort(kind="stable").argsort(kind="stable").astype(np.float32)
+    ranked = order / max(n - 1, 1)
+
+    seconds = np.arange(max(int(duration) + 1, 2), dtype=np.float32)
+    sample_seconds = np.clip(ratios * float(duration), 0.0, float(duration))
+
+    if sample_seconds[0] > 0:
+        sample_seconds = np.insert(sample_seconds, 0, 0.0)
+        ranked = np.insert(ranked, 0, ranked[0])
+    if sample_seconds[-1] < duration:
+        sample_seconds = np.append(sample_seconds, float(duration))
+        ranked = np.append(ranked, ranked[-1])
+
+    point_curve = np.interp(seconds, sample_seconds, ranked).astype(np.float32)
+    return _clip_scale_interest(point_curve)
+
+
+def _clip_scale_interest(curve: np.ndarray) -> np.ndarray:
+    """Turn point-like retention prominence into short clip-scale hot zones.
+
+    For every second, nearby high-retention values can raise its interest, with
+    a linear decay from 1.00 at the measured peak to 0.925 at +/-12 seconds.
+    This is a MAX envelope, not smoothing/averaging: measured peaks never move
+    and weaker neighbours cannot reduce them. Values stay in 0..1.
+
+    Why 12 seconds: Clips Kitty grows signal candidates to ~25 seconds. A
+    +/-12s envelope therefore makes one genuine retention peak meaningful over
+    approximately one candidate-sized window, while remaining much narrower
+    than the 60s maximum clip length.
+    """
+    if curve.size == 0:
+        return curve
+
+    radius = max(0, int(_RETENTION_CLIP_RADIUS_SECONDS))
+    if radius == 0:
+        return curve.astype(np.float32, copy=True)
+
+    base = np.asarray(curve, dtype=np.float32)
+    out = base.copy()
+
+    for offset in range(1, radius + 1):
+        frac = offset / radius
+        weight = 1.0 - (1.0 - _RETENTION_EDGE_WEIGHT) * frac
+
+        # A peak can influence the neighbouring second on either side, but
+        # never above its own height and never by shifting its true maximum.
+        out[offset:] = np.maximum(out[offset:], base[:-offset] * weight)
+        out[:-offset] = np.maximum(out[:-offset], base[offset:] * weight)
+
+    return np.clip(out, 0.0, 1.0).astype(np.float32)
+
+
 def _youtube_heatmap(url: str, duration: float) -> np.ndarray | None:
     """YouTube's own "most replayed" watch-time heatmap (popular videos only),
     resampled to per-second 0..1. This is real audience retention data."""
     import yt_dlp
-
     with yt_dlp.YoutubeDL({"quiet": True, "no_warnings": True, "skip_download": True}) as ydl:
         info = ydl.extract_info(url, download=False)
     heat = info.get("heatmap")
@@ -163,7 +393,6 @@ def _youtube_live_chat(url: str, video_id: str, duration: float) -> list[tuple[f
     import tempfile
 
     import yt_dlp
-
     with tempfile.TemporaryDirectory() as td:
         opts = {
             "quiet": True,
@@ -204,7 +433,6 @@ def _youtube_live_chat(url: str, video_id: str, duration: float) -> list[tuple[f
 
 def _chatters_to_curve(times: list[tuple[float, str]], duration: float) -> np.ndarray | None:
     """UNIQUE chatters per BIN_SECONDS window -> per-second percentile curve.
-
     Unique authors (not message counts) so gifted-sub message storms and
     emote spam from a handful of accounts can't fabricate a hype moment.
     Percentile-ranked within the video, like the audio/visual signals.

--- a/publish/youtube_shorts.py
+++ b/publish/youtube_shorts.py
@@ -1,11 +1,16 @@
 """YouTube Shorts upload via the YouTube Data API v3.
 
-The only external API in the system. One-time setup per user:
-  1. Google Cloud Console -> create project -> enable "YouTube Data API v3"
-  2. OAuth consent screen -> add yourself as a test user
-  3. Credentials -> OAuth client ID -> Desktop app -> download JSON
-     -> save as config/client_secret.json
-  4. python main.py auth   (opens browser once; token cached locally)
+One-time setup per user:
+1. Google Cloud Console -> create project -> enable "YouTube Data API v3"
+   and "YouTube Analytics API"
+2. OAuth consent screen -> add yourself as a test user
+3. Credentials -> OAuth client ID -> Desktop app -> download JSON
+   -> save as config/client_secret.json
+4. python main.py auth (opens browser once; token cached locally)
+
+Interactive authorization requests both the existing upload permission and
+read-only YouTube Analytics access. Uploading itself still requires only the
+original upload scope, so an existing upload-only token keeps working.
 
 Quota reality: each upload costs 1,600 of the default 10,000 daily units
 (hence the 6/day scheduler cap). Until Google verifies the app, API uploads
@@ -17,7 +22,9 @@ from pathlib import Path
 
 from publish.base import Publisher
 
-SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
+UPLOAD_SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
+ANALYTICS_SCOPE = "https://www.googleapis.com/auth/yt-analytics.readonly"
+AUTH_SCOPES = [*UPLOAD_SCOPES, ANALYTICS_SCOPE]
 
 
 class YouTubeShortsPublisher(Publisher):
@@ -34,14 +41,23 @@ class YouTubeShortsPublisher(Publisher):
     # ---- auth ----------------------------------------------------------
 
     def authenticate(self, interactive: bool = False):
-        """Returns valid credentials. interactive=True may open a browser
-        (the `auth` command); False raises if no cached token exists (daemon)."""
+        """Return valid credentials.
+
+        The explicit `auth` command requests every YouTube permission Clips
+        Kitty knows how to use: upload plus read-only Analytics. Background
+        uploads still require only the original upload scope, so an existing
+        upload-only token does not regress.
+        """
         from google.auth.transport.requests import Request
         from google.oauth2.credentials import Credentials
 
+        required_scopes = AUTH_SCOPES if interactive else UPLOAD_SCOPES
         creds = None
+
         if self.token_path.exists():
-            creds = Credentials.from_authorized_user_file(str(self.token_path), SCOPES)
+            creds = Credentials.from_authorized_user_file(str(self.token_path))
+            if not creds.has_scopes(required_scopes):
+                creds = None
 
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
@@ -50,16 +66,21 @@ class YouTubeShortsPublisher(Publisher):
         if not creds or not creds.valid:
             if not interactive:
                 raise RuntimeError(
-                    "No YouTube authorization yet. Run once:  python main.py auth"
+                    "No YouTube authorization yet. Run once: python main.py auth"
                 )
+
             if not self.client_secret.exists():
                 raise RuntimeError(
                     f"Missing {self.client_secret}. Follow README 'Enable uploads' "
                     "to create OAuth credentials in Google Cloud Console."
                 )
+
             from google_auth_oauthlib.flow import InstalledAppFlow
 
-            flow = InstalledAppFlow.from_client_secrets_file(str(self.client_secret), SCOPES)
+            flow = InstalledAppFlow.from_client_secrets_file(
+                str(self.client_secret),
+                required_scopes,
+            )
             creds = flow.run_local_server(port=0)
             self._save_token(creds)
 
@@ -90,6 +111,7 @@ class YouTubeShortsPublisher(Publisher):
                 "selfDeclaredMadeForKids": False,
             },
         }
+
         media = MediaFileUpload(str(video_path), chunksize=-1, resumable=True)
         request = self._service.videos().insert(
             part="snippet,status", body=body, media_body=media
@@ -98,4 +120,5 @@ class YouTubeShortsPublisher(Publisher):
         response = None
         while response is None:
             _, response = request.next_chunk()
+
         return response["id"]

--- a/tests/test_hype.py
+++ b/tests/test_hype.py
@@ -1,0 +1,96 @@
+import numpy as np
+
+from analysis import hype
+
+
+def test_organic_retention_spike_becomes_clip_scale_hot_zone():
+    duration = 432.0
+    rows = []
+    for i in range(1, 101):
+        ratio = i / 100.0
+        watch = 1.0 - (0.005 * i)
+        if i == 92:
+            watch += 0.20
+        rows.append([ratio, watch])
+
+    curve = hype._retention_rows_to_curve(rows, duration)
+
+    assert curve is not None
+    assert len(curve) == 433
+    assert 0.0 <= float(curve.min()) <= float(curve.max()) <= 1.0
+
+    peak_second = round(0.92 * duration)
+    assert float(curve[peak_second]) > 0.95
+
+    # The point-like Analytics peak is widened only enough to survive Clips
+    # Kitty's clip-window mean. It remains a local hot zone, not a video-wide
+    # lift.
+    local_mean = float(curve[peak_second - 12 : peak_second + 13].mean())
+    assert local_mean > 0.85
+    assert float(curve[peak_second - 30 : peak_second - 20].mean()) < local_mean
+
+
+def test_clip_scale_interest_preserves_peak_timestamp_and_value():
+    point_curve = np.zeros(101, dtype=np.float32)
+    point_curve[50] = 1.0
+
+    curve = hype._clip_scale_interest(point_curve)
+
+    assert int(curve.argmax()) == 50
+    assert float(curve[50]) == 1.0
+    assert float(curve[38]) >= 0.925 - 1e-6
+    assert float(curve[62]) >= 0.925 - 1e-6
+    assert float(curve[37]) == 0.0
+    assert float(curve[63]) == 0.0
+
+
+def test_youtube_prefers_authenticated_organic_curve(monkeypatch):
+    organic = np.linspace(0.0, 1.0, 61, dtype=np.float32)
+
+    monkeypatch.setattr(
+        hype,
+        "_youtube_organic_retention",
+        lambda video_id, duration: organic,
+    )
+
+    def public_heatmap_must_not_run(url, duration):
+        raise AssertionError("public heatmap should not run when organic data exists")
+
+    monkeypatch.setattr(hype, "_youtube_heatmap", public_heatmap_must_not_run)
+
+    result = hype.audience_curve(
+        "https://www.youtube.com/watch?v=owned",
+        "owned",
+        60.0,
+    )
+
+    assert result is organic
+
+
+def test_youtube_falls_back_to_existing_public_heatmap(monkeypatch):
+    public = np.linspace(1.0, 0.0, 61, dtype=np.float32)
+
+    monkeypatch.setattr(
+        hype,
+        "_youtube_organic_retention",
+        lambda video_id, duration: None,
+    )
+    monkeypatch.setattr(
+        hype,
+        "_youtube_heatmap",
+        lambda url, duration: public,
+    )
+
+    result = hype.audience_curve(
+        "https://www.youtube.com/watch?v=other",
+        "other",
+        60.0,
+    )
+
+    assert result is public
+
+
+def test_missing_oauth_token_is_normal_fallback(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLIPS_STUDIO_DATA_DIR", str(tmp_path))
+
+    assert hype._youtube_organic_retention("video", 60.0) is None

--- a/tests/test_youtube_auth.py
+++ b/tests/test_youtube_auth.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+from publish.youtube_shorts import (
+    ANALYTICS_SCOPE,
+    AUTH_SCOPES,
+    UPLOAD_SCOPES,
+    YouTubeShortsPublisher,
+)
+
+
+class FakeCredentials:
+    def __init__(self, scopes):
+        self.scopes = list(scopes)
+        self.expired = False
+        self.refresh_token = "refresh"
+        self.valid = True
+        self.refreshed = False
+
+    def has_scopes(self, scopes):
+        return set(scopes).issubset(self.scopes)
+
+    def refresh(self, request):
+        self.refreshed = True
+
+    def to_json(self):
+        return '{"token":"fake"}'
+
+
+def test_noninteractive_upload_accepts_existing_upload_only_token(
+    monkeypatch,
+    tmp_path,
+):
+    from google.oauth2 import credentials as credentials_module
+
+    token = tmp_path / "youtube_token.json"
+    token.write_text("{}", encoding="utf-8")
+    fake = FakeCredentials(UPLOAD_SCOPES)
+
+    monkeypatch.setattr(
+        credentials_module.Credentials,
+        "from_authorized_user_file",
+        staticmethod(lambda path: fake),
+    )
+
+    publisher = YouTubeShortsPublisher(
+        client_secret=tmp_path / "client_secret.json",
+        token_path=token,
+    )
+
+    assert publisher.authenticate(interactive=False) is fake
+
+
+def test_interactive_auth_upgrades_upload_only_token_to_analytics(
+    monkeypatch,
+    tmp_path,
+):
+    from google.oauth2 import credentials as credentials_module
+    from google_auth_oauthlib import flow as flow_module
+
+    token = tmp_path / "youtube_token.json"
+    token.write_text("{}", encoding="utf-8")
+    client_secret = tmp_path / "client_secret.json"
+    client_secret.write_text("{}", encoding="utf-8")
+
+    old = FakeCredentials(UPLOAD_SCOPES)
+    upgraded = FakeCredentials(AUTH_SCOPES)
+    seen = {}
+
+    monkeypatch.setattr(
+        credentials_module.Credentials,
+        "from_authorized_user_file",
+        staticmethod(lambda path: old),
+    )
+
+    class FakeFlow:
+        def run_local_server(self, port=0):
+            seen["port"] = port
+            return upgraded
+
+    def fake_from_client_secrets_file(path, scopes):
+        seen["path"] = Path(path)
+        seen["scopes"] = list(scopes)
+        return FakeFlow()
+
+    monkeypatch.setattr(
+        flow_module.InstalledAppFlow,
+        "from_client_secrets_file",
+        staticmethod(fake_from_client_secrets_file),
+    )
+
+    publisher = YouTubeShortsPublisher(
+        client_secret=client_secret,
+        token_path=token,
+    )
+
+    result = publisher.authenticate(interactive=True)
+
+    assert result is upgraded
+    assert ANALYTICS_SCOPE in seen["scopes"]
+    assert set(seen["scopes"]) == set(AUTH_SCOPES)
+    assert seen["path"] == client_secret
+    assert seen["port"] == 0
+    assert token.read_text(encoding="utf-8") == '{"token":"fake"}'


### PR DESCRIPTION
Summary

Adds the creator's organic YouTube audience retention as an optional
authenticated audience signal.

When the cached YouTube OAuth token includes yt-analytics.readonly, YouTube
videos first try YouTube Analytics with:

dimensions=elapsedVideoTimeRatio
metrics=audienceWatchRatio
filters=video==VIDEO_ID;audienceType==ORGANIC

If the user has no OAuth token, the token does not include Analytics, the video
belongs to another creator, or retention data is not available yet, Clips Kitty
falls back to the existing public Most Replayed / live-chat path.

Twitch and Kick are unchanged.

Why audienceType==ORGANIC

During testing, the Analytics curve without this filter did not reproduce the
visible YouTube Studio audience-retention peaks. Adding
audienceType==ORGANIC made the API curve line up with Studio on real channel
videos.

Turning retention into Clips Kitty's audience curve

audienceWatchRatio normally declines through a video, so absolute retention
would make the beginning of almost every upload look artificially "hot".

This implementation therefore:

compares each retention sample with a local median on both sides;

percentile-ranks those local lifts, matching the normalization convention
used by Clips Kitty's other signals;

suppresses the first 5%, where startup/autoplay behaviour is atypical;

interpolates the result to a per-second 0..1 curve;

gives each true retention peak a narrow +/-12 second clip-scale envelope.

The last step is needed because Clips Kitty consumes audience at clip scale:
the bonus averages the audience curve across the candidate window. A raw
1%-of-video Analytics point is otherwise diluted inside a normal 25-60 second
candidate. The envelope is a max operation, not smoothing: the true peak time
and value are preserved.

The +/-12s / 0.925 edge was chosen conservatively after testing the real curve:
on the six finalists from the first end-to-end run, only the finalist covering
the strong late retention region crossed the existing audience-bonus threshold.

OAuth compatibility

python main.py auth now asks for both:

youtube.upload

yt-analytics.readonly

Background uploading still requires only youtube.upload, so an existing
upload-only token continues to work. Re-running the explicit auth command
upgrades that token to include Analytics.

No browser is opened from the processing pipeline itself.

Real end-to-end validation

Tested against a 7:11 Italian YouTube video with known Studio retention peaks.

The isolated Analytics conversion reproduced the strongest late Studio peak at
about 06:37-06:38. With the change installed in a clean source checkout, the
full pipeline logged:

YouTube organic retention loaded (100 bins, OAuth)
Audience hype boosted 2 candidate(s) (max +8)

and completed transcription, multimodal analysis, ranking and rendering on
CUDA/Gemma without an audience-related error.

Fallback behaviour

Twitch: unchanged

Kick: unchanged

YouTube, no OAuth: existing public path

YouTube, OAuth but someone else's video: existing public path

YouTube, own video but no retention yet: existing public path

YouTube, own video with retention: organic retention

Tests

Adds offline deterministic tests for:

retention local-prominence conversion

clip-scale envelope behaviour

authenticated organic signal taking priority

public fallback when organic data is unavailable

missing-token fallback

existing upload-only OAuth tokens remaining valid for unattended uploads

explicit auth upgrading an upload-only token with Analytics permission